### PR TITLE
Native OS/browsers themes

### DIFF
--- a/_scss/dark.scss
+++ b/_scss/dark.scss
@@ -1,0 +1,22 @@
+@mixin dark-scheme {
+  --font-color: #e3e0d7;
+  --bg-color: #242424;
+  --heading-color: #fff;
+  --link-color: #80a0ff;
+  --link-color-visited: #d787ff;
+  --gabel-color: #ffffff;
+
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		@include dark-scheme;
+
+	}
+
+}
+
+[data-theme="dark"]:root {
+	@include dark-scheme;
+
+}

--- a/_scss/general.scss
+++ b/_scss/general.scss
@@ -1,23 +1,3 @@
-:root {
-  --font-color: #e3e0d7;
-  --bg-color: #242424;
-  --heading-color: #fff;
-  --link-color: #80a0ff;
-  --link-color-visited: #d787ff;
-  --gabel-color: #ffffff;
-
-}
-
-[data-theme="light"] {
-  --font-color: #566b78;
-  --bg-color: #fff;
-  --heading-color: #333;
-  --link-color: #00e;
-  --link-color-visited: #551A8B;
-  --gabel-color: #333;
-
-}
-
 html, body {
   font-family: "Helvetica", "Arial", sans-serif;
 };

--- a/_scss/light.scss
+++ b/_scss/light.scss
@@ -1,0 +1,22 @@
+@mixin light-scheme {
+  --font-color: #566b78;
+  --bg-color: #fff;
+  --heading-color: #333;
+  --link-color: #00e;
+  --link-color-visited: #551A8B;
+  --gabel-color: #333;
+
+}
+
+@media (prefers-color-scheme: light) {
+	:root {
+		@include light-scheme;
+
+	}
+
+}
+
+[data-theme="light"]:root {
+	@include light-scheme;
+
+}

--- a/css/style.scss
+++ b/css/style.scss
@@ -6,6 +6,8 @@
 
 $baseurl: "{{ site.baseurl }}";
 
+@import 'light';
+@import 'dark';
 @import 'general';
 @import 'switcher';
 @import 'responsive';

--- a/js/app.js
+++ b/js/app.js
@@ -1,26 +1,40 @@
 const toggleSwitch = document.querySelector('.theme-switch input[type="checkbox"]');
-const currentTheme = localStorage.getItem('theme');
+const matchMediaPrefLight = window.matchMedia('(prefers-color-scheme: light)');
+var currentTheme = localStorage.getItem('theme');
 
 if (currentTheme) {
 	document.documentElement.setAttribute('data-theme', currentTheme);
 
-	if (currentTheme === 'light') {
+	if (currentTheme === 'light' || matchMediaPrefLight.matches) {
 		toggleSwitch.checked = true;
 	}
 }
 
 function switchTheme(e) {
 	if (e.target.checked) {
-		document.documentElement.setAttribute('data-theme', 'light');
-		localStorage.setItem('theme', 'light');
+		currentTheme = 'light';
 	}
 	else {
-		document.documentElement.setAttribute('data-theme', 'dark');
-		localStorage.setItem('theme', 'dark');
+		currentTheme = 'dark';
+	}
+	document.documentElement.setAttribute('data-theme', currentTheme);
+	localStorage.setItem('theme', currentTheme);
+}
+
+function onSystemThemeChange(e) {
+	if (currentTheme) {
+		return;
+	}
+	if (e.matches) {
+		toggleSwitch.checked = true;
+	}
+	else {
+		toggleSwitch.checked = false;
 	}
 }
 
 toggleSwitch.addEventListener('change', switchTheme, false);
+matchMediaPrefLight.addEventListener('change', onSystemThemeChange)
 
 var easteregg = function(){
   console.log(`%c Welcome to`, "color:#00050f; font-family:monospace");


### PR DESCRIPTION
This PR changes the handling of the theme and considers the preference sent by the os/browser. It splits the theme colours into two `scss` files each consisting of a `mixin` with the respective colours and a media-selector and a data selector for the preference and theme chosen.
It additionally tweaks the `js` that the switcher follows the setting sent by the os/browser but stops as soon as the switcher is used to override the choice.