### PR TITLE
Fix initial toggle only running when theme is set

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5,9 +5,13 @@ var currentTheme = localStorage.getItem('theme');
 if (currentTheme) {
 	document.documentElement.setAttribute('data-theme', currentTheme);
 
-	if (currentTheme === 'light' || matchMediaPrefLight.matches) {
+	if (currentTheme === 'light') {
 		toggleSwitch.checked = true;
 	}
+}
+
+if (!currentTheme && matchMediaPrefLight.matches) {
+  toggleSwitch.checked = true;
 }
 
 function switchTheme(e) {


### PR DESCRIPTION
When coming from an unset state or a light theme the switch would not
toggle according the state. So you had to toggle it once to light theme
and back again to dark.

This was an error because the check for the media preference for light
theme (unset) was included in the check for the localStorage key `theme`

Was fixed duplicating this toggle and run it if currentTheme is not set
and media preference matches light.