### PR TITLE
Fix baseurl "" instead of "/" and fix asset-paths

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 ---
 
 title: Prädikat
-baseurl: "/"
+baseurl: ""
 url: "https://prädik.at"
 
 markdown: kramdown
@@ -9,9 +9,6 @@ markdown: kramdown
 sass:
   sass_dir: _scss
   style: :compressed
-
-plugins:
-  - jekyll
 
 compress_html:
   clippings: []
@@ -24,3 +21,4 @@ compress_html:
   startings: []
 
 permalink: /:title
+# permalink: pretty

--- a/_includes/lateload.html
+++ b/_includes/lateload.html
@@ -1,2 +1,2 @@
-<script type="text/javascript" src="{{ site.baseurl }}js/modernizr.js"></script>
-<script type="text/javascript" src="{{ site.baseurl }}js/app.js"></script>
+<script type="text/javascript" src="{{ site.baseurl }}/js/modernizr.js"></script>
+<script type="text/javascript" src="{{ site.baseurl }}/js/app.js"></script>


### PR DESCRIPTION
To stay consistent with how jekyll assumes/handles `baseurl` this needs to be empty and every (asset-)path needs to start with a `/`.