### PR TITLE
Add jekyll plugins to enable local development

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,11 @@ sass:
   sass_dir: _scss
   style: :compressed
 
+plugins:
+  - jekyll-default-layout
+  - jekyll-optional-front-matter
+  - jekyll-titles-from-headings
+
 compress_html:
   clippings: []
   comments: []


### PR DESCRIPTION
There is a fixed set of jekyll plugins that is always enabled on github
pages environments. [0]
Some of those silently enable this site to function while locally it
fails
- jekyll-default-layout
- jekyll-optional-front-matter
- jekyll-titles-from-headings

If those are enabled it builds locally.

[0] https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll#plugins